### PR TITLE
Improve and simplify blank HTML template

### DIFF
--- a/blank-web/app/index.html
+++ b/blank-web/app/index.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hello World</title>
-  <link href='/style.css' rel='stylesheet'>
+  <link href="/style.css" rel="stylesheet">
 </head>
 <body>
   <h1>Hello, world!</h1>
   <button onclick="console.log('hello');">Press me</button>
-  <script defer type="text/javascript" src="/main.js"></script>
+  <script defer src="/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Use double quotes consistently.
- Don't use self-closing tag syntax.
- Remove unnecessary default script type.