### PR TITLE
Update Gemini template [JavaScript Web App (Vite)] to new SDK

### DIFF
--- a/gemini/js-web/README.md
+++ b/gemini/js-web/README.md
@@ -1,0 +1,26 @@
+# Gemini JavaScript Web Demo
+
+<a href="https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2Fproject-idx%2Ftemplates%2Ftree%2Fmain%2Fgemini%2Fjs-web">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://cdn.idx.dev/btn/open_dark_32.svg">
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://cdn.idx.dev/btn/open_light_32.svg">
+    <img
+      height="32"
+      alt="Open in IDX"
+      src="https://cdn.idx.dev/btn/open_purple_32.svg">
+  </picture>
+</a>
+
+This is a simple demonstration web app using the Gemini API with JavaScript to generate recipes from images.
+
+## Getting Started
+
+1. Get an API key from https://g.co/ai/idxGetGeminiKey.
+2. In the `.idx/dev.nix` file, replace `"<YOUR_API_KEY>"` with your actual API key. The environment will then automatically rebuild.
+3. Open a new terminal (`Ctrl` + `` ` ``).
+4. Run `npm install` to install the necessary packages.
+5. Run `npm start` to run the application.

--- a/gemini/js-web/package.json
+++ b/gemini/js-web/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@google/genai": "^1.0.1",
+    "@google/genai": "^1.21.0",
     "base64-js": "^1.5.1",
     "markdown-it": "^13.0.2"
   },


### PR DESCRIPTION
Migrate generative AI SDK to the new [JS SDK](https://www.npmjs.com/package/@google/genai)

- Older vesion: 1.0.1
- Newer Version: 1.21.0

Add README and update template metadata

[Open IDX](https://idx.google.com/new?template=https://github.com/veera-firebase/templates/tree/main/gemini)