### PR TITLE
Modify the idx-template.json file in astro template @rodydavis

### DIFF
--- a/astro/idx-template.json
+++ b/astro/idx-template.json
@@ -5,7 +5,7 @@
     "Web app"
   ],
   "icon": "http://foo.svg",
-  "publisher": {},
+  "publisher": "Google",
   "params": [
     {
       "id": "template",


### PR DESCRIPTION
Update the publisher name in idx-template.json file in astro template.

Previous error : Template not working due to publisher type in idx-template.json file.
Solution : Add publisher name with string type.