### PR TITLE
Add composer support to php API server template

### DIFF
--- a/php/app/.idx/dev.nix
+++ b/php/app/.idx/dev.nix
@@ -6,6 +6,7 @@
   # Use https://search.nixos.org/packages to find packages
   packages = [
     pkgs.php
+    pkgs.phpPackages.composer
   ];
   # Sets environment variables in the workspace
   env = {};


### PR DESCRIPTION
This PR integrates Composer into the PHP API server template to allow for easy management of external dependencies.
I have personally used and tested this setup, and it works great for pulling in the packages needed for a project if wanted one add  composer.json for dependency management.

<a href="https://idx.google.com/new?template=https://github.com/shaiksahilrizwan/templates/tree/feat-add-feature-php-template/php">
  <img height="32" alt="Open in IDX" src="https://cdn.idx.dev/btn/open_dark_32.svg">
</a>