### PR TITLE
Modify the dev.nix file in qwik-vite template @rodydavis

### DIFF
--- a/qwik-vite/dev.nix
+++ b/qwik-vite/dev.nix
@@ -2,7 +2,7 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-25.05"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable".
   # Use https://search.nixos.org/packages to find packages
   packages = [
     pkgs.nodejs_24


### PR DESCRIPTION
Update the Nodejs and channel version in dev.nix file in qwik-vite template.
 
Previous error : Template not working due to not compatible with vite version and previous version of nodejs in dev.nix file.
Solution : Modify the nodejs and channel version in dev.nix file.