### PR TITLE
Modify the dev.nix file for HTMX-GO template @rodydavis

### DIFF
--- a/htmx/go/.idx/dev.nix
+++ b/htmx/go/.idx/dev.nix
@@ -35,7 +35,6 @@
     workspace = {
       # Runs when a workspace is first created with this `dev.nix` file
       onCreate = {
-        npm-install = "npm ci --no-audit --prefer-offline --no-progress --timing";
         # Open editors for the following files by default, if they exist:
         default.openFiles = [ "main.go" "index.html" ];
       };


### PR DESCRIPTION
Update the dev.nix file in htmx-go template.
 
Previous error : Template giving error due to npm clean install command in dev.nix file.
Solution : Removing the npm clean install command line in dev.nix file.