### PR TITLE
Add Vertex AI Agent Garden template

### DIFF
--- a/agent-garden/.idx/dev.nix
+++ b/agent-garden/.idx/dev.nix
@@ -1,0 +1,67 @@
+
+# To learn more about how to use Nix to configure your environment
+# see: https://firebase.google.com/docs/studio/customize-workspace
+{ pkgs, ... }: {
+  # Which nixpkgs channel to use.
+  channel = "stable-25.05"; # or "unstable"
+
+  # Use https://search.nixos.org/packages to find packages
+  packages = [
+    pkgs.uv
+    pkgs.gnumake
+    pkgs.terraform
+    pkgs.gh
+  ];
+  # Sets environment variables in the workspace
+  env = {};
+  idx = {
+    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
+    extensions = [
+    ];
+    workspace = {
+      # Runs when a workspace is first created with this `dev.nix` file
+      onCreate = {
+        create-venv = ''
+        # Load environment variables from .env file if it exists
+        source .env
+
+        # Warm up agent-starter-pack in background while user sets up gcloud
+        (uvx agent-starter-pack --help > /dev/null 2>&1 &)
+
+        echo ""
+        echo "╔════════════════════════════════════════════════════════════╗"
+        echo "║                  🔐 GCLOUD SETUP REQUIRED                  ║"
+        echo "╚════════════════════════════════════════════════════════════╝"
+        echo ""
+        echo "📝 Before proceeding, please ensure:"
+        echo "   1️⃣  You are logged in to gcloud"
+        echo "   2️⃣  You have selected the correct project"
+        echo ""
+
+        auth_status=$(gcloud auth list --quiet 2>&1)
+
+        echo ""
+        echo "⚙️  We will now set the project you want to use..."
+        gcloud config get project
+
+        echo ""
+        echo "💡 Need to setup? Run these commands:"
+        echo "   → gcloud auth login"
+        echo "   → gcloud config set project YOUR_PROJECT_ID"
+        echo ""
+
+        echo "Running agent starter pack creation..."
+        echo adk@$AGENT_NAME
+        uvx agent-starter-pack create $AGENT_NAME -ag -a adk@$AGENT_NAME -d agent_engine --region $REGION --auto-approve
+        code ~/$WS_NAME/$AGENT_NAME/README.md
+        exec bash
+        '';
+        # Open editors for the following files by default, if they exist:
+        default.openFiles = [];
+      };
+      # To run something each time the workspace is (re)started, use the `onStart` hook
+    };
+    # Enable previews and customize configuration
+    previews = {};
+  };
+}

--- a/agent-garden/README.md
+++ b/agent-garden/README.md
@@ -1,0 +1,30 @@
+# Vertex AI Agent Garden
+
+<a href="https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2Ffirebase-studio%2Ftemplates%2Ftree%2Fmain%2Fagent-garden">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://cdn.idx.dev/btn/open_dark_32.svg">
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://cdn.idx.dev/btn/open_light_32.svg">
+    <img
+      height="32"
+      alt="Open in IDX"
+      src="https://cdn.idx.dev/btn/open_purple_32.svg">
+  </picture>
+</a>
+
+This template bootstraps an agent workspace from an agent stored Google Cloud's Agent Garden and using the CLI (https://github.com/GoogleCloudPlatform/agent-starter-pack) library.
+
+## Getting Started
+
+You'll be prompted for:
+1. **Agent Name**: The agent template to use (e.g., 'data-science', 'customer-support')
+2. **Region**: Google Cloud region for deployment
+
+
+## Learn More
+
+- [Agent Starter Pack](https://github.com/GoogleCloudPlatform/agent-starter-pack)
+- [Agent Development Kit Samples](https://github.com/google/adk-samples)

--- a/agent-garden/idx-template.json
+++ b/agent-garden/idx-template.json
@@ -1,0 +1,22 @@
+{
+  "name": "Agent Garden",
+  "description": "Agent Garden is a library in the Google Cloud console where you can find and explore sample agents and tools that are designed to accelerate your development.",
+  "categories": ["AI & ML"],
+  "icon": "https://github.com/GoogleCloudPlatform/agent-starter-pack/blob/main/docs/images/icon.png?raw=true",
+  "params": [
+    {
+      "id": "adk_agent_name",
+      "name": "Agent Name",
+      "description": "The name of the agent template from the google/adk-samples repository (e.g., 'data-science').",
+      "type": "string",
+      "required": true
+    },
+    {
+      "id": "region",
+      "name": "Region",
+      "description": "The Google Cloud region where the agent will be deployed.",
+      "type": "string",
+      "required": false
+    }
+  ]
+}

--- a/agent-garden/idx-template.nix
+++ b/agent-garden/idx-template.nix
@@ -1,0 +1,27 @@
+
+# No user-configurable parameters
+# Accept additional arguments to this template corresponding to template
+# parameter IDs
+{ pkgs, adk_agent_name ? "", region ? "us-central1", ... }: {
+  # Shell script that produces the final environment
+  bootstrap = ''
+    # Copy the folder containing the `idx-template` files to the final
+    # project folder for the new workspace. ${./.} inserts the directory
+    # of the checked-out Git folder containing this template.
+    cp -rf ${./.} "$out"
+
+    # Set some permissions
+    chmod -R +w "$out"
+
+    # Create .env file with the parameter values
+    cat > "$out/.env" << EOF
+    AGENT_NAME=${adk_agent_name}
+    REGION=${region}
+    WS_NAME=$WS_NAME
+    EOF
+
+    # Remove the template files themselves and any connection to the template's
+    # Git repository
+    rm -rf "$out/.git" "$out/idx-template".{nix,json}
+  '';
+}


### PR DESCRIPTION
## Summary
- Adds new template for bootstrapping agent workspaces from Google Cloud's Agent Garden
- Integrates with Agent Starter Pack CLI for streamlined agent setup
- Includes configuration for agent selection and region deployment

Test link: 
https://studio.firebase.google.com/new?template=https:%2F%2Fgithub.com%2Feliasecchig%2Ftemplates%2Ftree%2Ffeat-add-agent-garden-template%2Fagent-garden&adk_agent_name=gemini-fullstack&region=us-central1
