### PR TITLE
Modify the dev.nix file in qwik-city-vite template @rodydavis

### DIFF
--- a/qwik-city-vite/dev.nix
+++ b/qwik-city-vite/dev.nix
@@ -2,10 +2,10 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.nodejs_20
+    pkgs.nodejs_24
   ];
   # Sets environment variables in the workspace
   env = {};


### PR DESCRIPTION
Update the Nodejs and channel version in dev.nix file in qwik-city-vite template.

Previous error : Template not working due to not compatible with vite version and previous version of nodejs in dev.nix file.
Solution : Modify the nodejs and channel version in [dev.nix](https://github.com/firebase-studio/templates/pull/165/files#diff-644cb0ddf1b15b428db5d4ad827abd4e0a7d2552c7e92eb75baa731999fd3294) file.