### PR TITLE
Update go [WEB-html template] with channel and go version in dev.nix file @rodydavis

### DIFF
--- a/go/web-template/.idx/dev.nix
+++ b/go/web-template/.idx/dev.nix
@@ -2,7 +2,7 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
     pkgs.go
@@ -19,6 +19,7 @@
     workspace = {
       onCreate = {
         # Open editors for the following files by default, if they exist:
+        go-mod-tidy = "go mod tidy";
         default.openFiles = ["main.go"];
       };
     };


### PR DESCRIPTION
Update go version and channel

channel : older (23.11) -> newer (25.05)
go: older(1.22) -> newer(1.24.6)
Adding "go mod tidy" 
go mod tidy will add the necessary module and its version to the go.mod file.


<a href="https://idx.google.com/new?template=https://github.com/MoulikCTS/templates/tree/go-web-html-template/go">
  <picture>
    <source
      media="(prefers-color-scheme: dark)"
      srcset="https://cdn.firebasestudio.dev/btn/open_dark_32.svg">
    <source
      media="(prefers-color-scheme: light)"
      srcset="https://cdn.firebasestudio.dev/btn/open_light_32.svg">
    <img
      height="32"
      alt="Open in Firebase Studio"
      src="https://cdn.firebasestudio.dev/btn/open_blue_32.svg">
  </picture>
</a>