### PR TITLE
Update GO WEB-TEMPLATE with (go.googlesource) url in main.go file @rodydavis

### DIFF
--- a/go/web-template/main.go
+++ b/go/web-template/main.go
@@ -21,10 +21,10 @@ import (
 var (
 	httpAddr   = flag.String("addr", "0.0.0.0:8080", "Listen address")
 	pollPeriod = flag.Duration("poll", 5*time.Second, "Poll period")
-	version    = flag.String("version", "1.20", "Go version")
+	version    = flag.String("version", "1.24", "Go version")
 )
 
-const baseChangeURL = "https://go.googlesource.com/go/+/"
+const baseChangeURL = "https://go.googlesource.com/go/+/refs/heads/release-branch."
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
Earlier the [url](https://go.googlesource.com/go/+/go1.20) was only working for checking go 1.20 version, if we are changing the version the  [url](https://go.googlesource.com/go/+/) was not working.

**Solution**
update it to new [url](https://go.googlesource.com/go/+/refs/heads/release-branch.), which will work on all the versions.



<a href="https://idx.google.com/new?template=https://github.com/MoulikCTS/templates/tree/go-html-url-change/go">
  <picture>
    <source
      media="(prefers-color-scheme: dark)"
      srcset="https://cdn.firebasestudio.dev/btn/open_dark_32.svg">
    <source
      media="(prefers-color-scheme: light)"
      srcset="https://cdn.firebasestudio.dev/btn/open_light_32.svg">
    <img
      height="32"
      alt="Open in Firebase Studio"
      src="https://cdn.firebasestudio.dev/btn/open_blue_32.svg">
  </picture>
</a>