### PR TITLE
update adk to the latest version @rodydavis

### DIFF
--- a/adk/.idx/dev.nix
+++ b/adk/.idx/dev.nix
@@ -2,9 +2,9 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
-  packages = [ pkgs.python3 ];
+  packages = [ pkgs.python314 ];
   idx = {
     # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
     extensions = [ "ms-python.python" ];


### PR DESCRIPTION
Migrate the package version of adk, python and channel.

- python : older (3.11) -> newer (3.14.0)
- channel : older (24.05) -> newer (25.05)

<a href="https://studio.firebase.google.com/new?template=https%3A%2F%2Fgithub.com%2FSahibafirebase%2Ftemplates%2Ftree%2Ffeat-update-adk-template%2Fadk">
  <img
    height="32"
    alt="Open in Firebase Studio"
    src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>
