### PR TITLE
Update dotnet sdk version of dotnet template @rodydavis

### DIFF
--- a/dotnet/devNix.j2
+++ b/dotnet/devNix.j2
@@ -2,10 +2,10 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.dotnet-sdk_9
+    pkgs.dotnet-sdk_10
   ];
   # Sets environment variables in the workspace
   env = {};

--- a/dotnet/idx-template.nix
+++ b/dotnet/idx-template.nix
@@ -1,6 +1,6 @@
 { pkgs, environment ? "blazor", ... }: {
-  channel = "stable-24.11";
-  packages = [ pkgs.dotnet-sdk_9 pkgs.j2cli pkgs.nixfmt ];
+  channel = "stable-25.05";
+  packages = [ pkgs.dotnet-sdk_10 pkgs.j2cli pkgs.nixfmt ];
   bootstrap = ''
     export HOME=/home/user
     dotnet new ${environment} -o "$WS_NAME"


### PR DESCRIPTION
Update the package version of dotnet sdk and channel.

dotnet sdk : older (9) -> newer (10)
channel : older (24.11) -> newer (25.05)

<a href="https://idx.google.com/new?template=https://github.com/Naveen-1913/templates/tree/feat-update-dotnet-template/dotnet">
  <img height="32" alt="Try in IDX" src="https://cdn.idx.dev/btn/try_dark_32.svg">
</a>