### PR TITLE
Update Rust template to latest channel version @rodydavis

### DIFF
--- a/rust/dev.nix
+++ b/rust/dev.nix
@@ -2,7 +2,7 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
     pkgs.cargo


### PR DESCRIPTION
Update the channel version from stable 24.05 to 25.05

<a href="https://studio.firebase.google.com/new?template=https://github.com/farhan-aboobacker/templates/tree/chore-update-channel-version-rust-template/rust">
  <img height="32" alt="Open in Firebase Studio" src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>