### PR TITLE
Update idx-template.nix for bootstrap @rodydavis 

### DIFF
--- a/nuxt/idx-template.nix
+++ b/nuxt/idx-template.nix
@@ -16,7 +16,7 @@
       npx nuxi@latest -y init "$out" \
         --package-manager ${packageManager} \
         --no-install \
-        --git-init
+        --git-init  <<< "No"
 
       mkdir "$out"/.idx
       cp ${./dev.nix} "$out"/.idx/dev.nix


### PR DESCRIPTION
Problem:
Nuxt CLI still creates a Git repository and prompts for module installation during setup. This behavior persists because nuxi internally handles --git-init in a way that ignores redirected input, making automation difficult.

Solution:
Update the Nuxt project initialization command to run non-interactively and suppress Git prompts. While this change reduces manual intervention, further refinement may be needed to fully eliminate Git and module prompts for complete automation.

Fix:
  Old : npx nuxi@latest -y init "$out" \
        --package-manager ${packageManager} \
        --no-install \
        --git-init

New : npx nuxi@latest -y init "$out" \
        --package-manager ${packageManager} \
        --no-install \
        --git-init  **<<< "No"**

<a href="https://idx.google.com/new?template=https:%2F%2Fgithub.com%2Frichavijayvargiya%2Ftemplates%2Ftree%2Ffeature-update-boot-nuxt-template%2Fnuxt" rel="nofollow">
  <img height="32" alt="Open in Firebase Studio" src="https://camo.githubusercontent.com/6448d1b75b1d6237a6374dc31659263761b13cb4726a18cf183f2990c3989d3e/68747470733a2f2f63646e2e666972656261736573747564696f2e6465762f62746e2f6f70656e5f6272696768745f33322e737667" data-canonical-src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg" style="max-width: 100%; height: auto; max-height: 32px;">
</a>
