### PR TITLE
Update idx-template.nix and dev.nix to solve web preview load issue @rodydavis

### DIFF
--- a/nuxt/dev.nix
+++ b/nuxt/dev.nix
@@ -2,11 +2,12 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 {pkgs}: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.05"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.nodejs_20
+    pkgs.nodejs_24
     PM_NIX_PACKAGE
+    pkgs.nodePackages.npm-check-updates
   ];
   # Sets environment variables in the workspace
   env = {};
@@ -29,7 +30,7 @@
       enable = true;
       previews = {
         web = {
-          command = ["npm" "run" "dev" "--" "--port" "$PORT" "--hostname" "0.0.0.0"];
+          command = ["sh" "-c" "PM_INSTALL && npm" "run" "dev" "--" "--port" "$PORT" "--hostname" "0.0.0.0"];
           manager = "web";
         };
       };

--- a/nuxt/idx-template.nix
+++ b/nuxt/idx-template.nix
@@ -31,6 +31,10 @@
           "${packageManager} install"        
       }/g" "$out"/.idx/dev.nix
 
+      sed -i "s/PM_INSTALL/${
+            "${packageManager} install"        
+      }/g" "$out"/.idx/dev.nix
+      
       sed -i "s/PM_NIX_PACKAGE/${
         if packageManager == "npm" then
           ""


### PR DESCRIPTION
Problem
Web Preview was failing due to a race condition where the development server started before dependencies were installed.
Solution
- Updated Nix channel and Node.js version to ensure compatibility and stability.
- Added pkgs.nodePackages.npm-check-updates to help upgrade package.json dependencies to their latest versions.
- Ensured packageManager install runs before starting the development server to avoid race conditions.
Fix Details
Channel Update:
Old: channel = "stable-23.05"; # or "unstable"
New: channel = "stable-**25**.05"; # or "unstable"
Node.js Version:
Old: pkgs.nodejs_20
New: pkgs.nodejs_**24**
New Package Added:
**pkgs.nodePackages.npm-check-updates**
Command Update:
Old:
command = [ "npm", "run", "dev", "--", "--port", "$PORT", "--hostname", "0.0.0.0" ];
New:
command = [ **"sh", "-c", "PM_INSTALL &&** npm run dev -- --port $PORT --hostname 0.0.0.0" ];
Dynamic Install Injection:
                             **sed -i "s/PM_INSTALL/${
                             "${packageManager} install"        
                            }/g" "$out"/.idx/dev.nix**


<a href="https://idx.google.com/new?template=https:%2F%2Fgithub.com%2Frichavijayvargiya%2Ftemplates%2Ftree%2Ffeature-update-boot-nuxt-template%2Fnuxt" rel="nofollow">
  <img height="32" alt="Open in Firebase Studio" src="https://camo.githubusercontent.com/6448d1b75b1d6237a6374dc31659263761b13cb4726a18cf183f2990c3989d3e/68747470733a2f2f63646e2e666972656261736573747564696f2e6465762f62746e2f6f70656e5f6272696768745f33322e737667" data-canonical-src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg" style="max-width: 100%; height: auto; max-height: 32px;">
</a>
