### PR TITLE
Update nodejs package version and channel version of dataconnect template @rodydavis

### DIFF
--- a/data-connect/flutter/dev.nix
+++ b/data-connect/flutter/dev.nix
@@ -3,7 +3,7 @@
 { pkgs, ... }: {
 
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
 
   services.postgres = {
     extensions = ["pgvector"];
@@ -13,7 +13,7 @@
   
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.nodejs_20
+    pkgs.nodejs_24
     (pkgs.postgresql_15.withPackages (p: [ p.pgvector ]))
     pkgs.nodePackages.pnpm
     pkgs.jdk17


### PR DESCRIPTION
Update channel and package version in dev.nix file

- channel: older(24.05) -> newer(25.05)
- nodejs: older(20) -> newer(24)

<a href="https://studio.firebase.google.com/new?template=https://github.com/farhan-aboobacker/templates/tree/feat-update-dataconnect-flutter-template/data-connect">
  <img height="32" alt="Open in Firebase Studio" src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>