### PR TITLE
Add gitignore to MongoDB template projects

### DIFF
--- a/mongodb/blank/.gitignore
+++ b/mongodb/blank/.gitignore
@@ -1,0 +1,5 @@
+# Dependencies
+node_modules/
+
+# Logs
+npm-debug.log*

--- a/mongodb/express/.gitignore
+++ b/mongodb/express/.gitignore
@@ -1,0 +1,5 @@
+# Dependencies
+node_modules/
+
+# Logs
+npm-debug.log*

--- a/mongodb/flask/.gitignore
+++ b/mongodb/flask/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.pyc
+
+# Virtual environment
+venv/
+.venv/
+
+# Flask instance folder
+instance/


### PR DESCRIPTION
This PR adds minimal `.gitignore` files to the MongoDB template projects to prevent unnecessary or environment-specific files from being committed.

Each `.gitignore` file has entries for common generated artifacts, such as `node_modules/` and build outputs.