### PR TITLE
Update blank-web template to the latest version @rodydavis

### DIFF
--- a/blank-web/app/.idx/dev.nix
+++ b/blank-web/app/.idx/dev.nix
@@ -2,10 +2,10 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.nodejs_20
+    pkgs.nodejs_24
     pkgs.python3
   ];
   # Sets environment variables in the workspace


### PR DESCRIPTION
Update package and channel versions

- nodejs : older (20) -> newer (24)
- channel : older (23.11) -> newer (25.05)

<a href="https://studio.firebase.google.com/new?template=https://github.com/Naveen-1913/templates/tree/feat-update-blank-web/blank-web">
  <img height="32" alt="Open in Firebase Studio" src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>