### PR TITLE
Update prisma [postgres] template dependencies version @rodydavis

### DIFF
--- a/prisma/app-ppg/.idx/dev.nix
+++ b/prisma/app-ppg/.idx/dev.nix
@@ -2,7 +2,7 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
 
   # Use https://search.nixos.org/packages to find packages
   packages = [

--- a/prisma/app-ppg/package.json
+++ b/prisma/app-ppg/package.json
@@ -7,9 +7,9 @@
   },
   "dependencies": {
     "@prisma/client": "6.2.0",
-    "@prisma/extension-accelerate": "1.2.1",
-    "@types/node": "22.10.5",
-    "dotenv": "16.4.7"
+    "@prisma/extension-accelerate": "2.0.2",
+    "@types/node": "24.10.1",
+    "dotenv": "17.2.3"
   },
   "devDependencies": {
     "prisma": "6.2.0",


### PR DESCRIPTION
Update dependencies version and channel version.

- prisma/extension-accelerate : older (1.2.1) -> newer (2.0.2)
- types/node : older (22.10.5) -> newer (24.10.1)
- dotenv : older (16.4.7) -> newer (17.2.3)
- channel : older (24.05) -> newer (25.05)

<a href="https://studio.firebase.google.com/new?template=https://github.com/Naveen-1913/templates/tree/feat-update-Prisma-Postgres/prisma">
  <img height="32" alt="Open in Firebase Studio" src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>