### PR TITLE
Update the react-router command in idx-template.nix file for remix template @rodydavis

### DIFF
--- a/remix/dev.nix
+++ b/remix/dev.nix
@@ -2,10 +2,10 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.nodejs_20
+    pkgs.nodejs_24
   ];
   # Sets environment variables in the workspace
   env = {};
@@ -28,8 +28,7 @@
       enable = true;
       previews = {
         web = {
-          command = ["npm" "run" "dev"];
-          env = { PORT = "$PORT";};
+          command = ["npm" "run" "dev" "--" "--port" "$PORT" "--host" "0.0.0.0"];
           manager = "web";
         };
       };

--- a/remix/idx-template.nix
+++ b/remix/idx-template.nix
@@ -4,18 +4,18 @@
     pkgs.git
   ];
   bootstrap = ''
-    npx create-remix@latest --yes --no-install --no-git-init --no-init-script "$WS_NAME"
-    mkdir -p "$WS_NAME/.idx/"
-    cp -rf ${./dev.nix} "$WS_NAME/.idx/dev.nix"
-    chmod -R +w "$WS_NAME"
-    mv "$WS_NAME" "$out"
-
-    mkdir -p "$out/.idx"
-    chmod -R u+w "$out"
-    cp -rf ${./.idx/airules.md} "$out/.idx/airules.md"
-    cp -rf "$out/.idx/airules.md" "$out/GEMINI.md"
-    chmod -R u+w "$out"
-
-    cd "$out"; npm install --package-lock-only --ignore-scripts
+    set -ex
+    mkdir -p "$out"
+    cd "$out"
+    npx create-react-router@latest . --typescript --no-install --no-git-init --yes
+    if [ ! -f "package.json" ]; then
+      exit 1
+    fi
+    mkdir -p .idx
+    cp -rf ${./dev.nix} .idx/dev.nix
+    cp -rf ${./.idx/airules.md} .idx/airules.md
+    cp -f .idx/airules.md GEMINI.md
+    chmod -R u+w .
+    npm install --package-lock-only --ignore-scripts
   '';
 }


### PR DESCRIPTION
Update the react-router command and related code changes in idx-template.nix file because remix is now react-router v7

remix command : npx create-remix@latest 
react-router : npx create-react-router@latest

<img width="1364" height="300" alt="Screenshot 2025-11-26 171611" src="https://github.com/user-attachments/assets/96f9769b-19e0-47f6-8b9b-a02cc6648b66" />


Update nixos channel, nodejs version to latest and preview section in dev.nix file

nodejs : older (20) -> newer (24)
channel : older (23.11) -> newer (25.05)

<a href="https://studio.firebase.google.com/new?template=https://github.com/KarthiMoorthi-37/templates/tree/FBS_remix/remix">
  <img
    height="32"
    alt="Open in Firebase Studio"
    src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>
