### PR TITLE
Update Dart template with latest channel version @rodydavis

### DIFF
--- a/dart/app/dev.nix
+++ b/dart/app/dev.nix
@@ -2,7 +2,7 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
     pkgs.dart


### PR DESCRIPTION
Update Channel Version
Older (23.11) -> Newer(25.05)

<a href="https://idx.google.com/new?template=https://github.com/richavijayvargiya/templates/tree/feat-update-dart-template/dart">
<img height="32" alt="Open in Firebase Studio" src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>
