### PR TITLE
Update expo and channel version in react-native @rodydavis

### DIFF
--- a/react-native/devNix.j2
+++ b/react-native/devNix.j2
@@ -13,7 +13,7 @@
     },
     "pnpm": {
         "packages": "pkgs.nodePackages.pnpm",
-        "install": "pnpm add @expo/ngrok@^4.1.0",
+        "install": "pnpm add @expo/ngrok@^4.1.0 @expo/metro-runtime",
         "previewWebPrefix": "\"pnpm\" \"web\"",
         "previewAndroidPrefix": "pnpm android"
     },
@@ -27,7 +27,7 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-23.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [{{perPackageManager.packages}}];
   # Sets environment variables in the workspace

--- a/react-native/idx-template.json
+++ b/react-native/idx-template.json
@@ -18,7 +18,8 @@
       "options": {
         "npm": "npm",
         "pnpm": "pnpm",
-        "bun": "bun"
+        "bun": "bun",
+        "yarn": "yarn"
       },
       "required": true
     }


### PR DESCRIPTION
Problem
Web Preview was failing due to expo was not updated and channel version.
Solution
updated channel version and added expo runtime dependency.

<a href="https://studio.firebase.google.com/new?template=https://github.com/sampathkumar4/templates/tree/FBS_ReactNative/react-native">
  <img
    height="32"
    alt="Open in Firebase Studio"
    src="https://cdn.firebasestudio.dev/btn/open_dark_32.svg">
</a>