### PR TITLE
Update dotnet sdk version of dotnet template @rodydavis

### DIFF
--- a/dotnet/devNix.j2
+++ b/dotnet/devNix.j2
@@ -5,7 +5,7 @@
   channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.dotnet-sdk_10
+    pkgs.dotnet-sdk
   ];
   # Sets environment variables in the workspace
   env = {};

--- a/dotnet/idx-template.nix
+++ b/dotnet/idx-template.nix
@@ -1,6 +1,6 @@
 { pkgs, environment ? "blazor", ... }: {
   channel = "stable-25.05";
-  packages = [ pkgs.dotnet-sdk_10 pkgs.j2cli pkgs.nixfmt ];
+  packages = [ pkgs.dotnet-sdk pkgs.j2cli pkgs.nixfmt ];
   bootstrap = ''
     export HOME=/home/user
     dotnet new ${environment} -o "$WS_NAME"


### PR DESCRIPTION
Update the package version of dotnet sdk

- dotnet sdk : older (9) -> newer (dotnet-sdk)

Previously, with the dotnet-sdk-9 or dotnet-sdk-10 packages, the dotnet-blazor web preview was not working because of compatibility issues. However, with the standard dotnet-sdk package, the web preview is now working

<a href="https://studio.firebase.google.com/new?template=https://github.com/Naveen-1913/templates/tree/feat-update-dotnet-template/dotnet">
  <img height="32" alt="Open in Firebase Studio" src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>