### PR TITLE
Add Spring Security to Java API Server Template with default User Credentials

### DIFF
--- a/java/app/pom.xml
+++ b/java/app/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/app/src/main/java/com/example/demo/DemoApplication.java
+++ b/java/app/src/main/java/com/example/demo/DemoApplication.java
@@ -36,5 +36,4 @@ public class DemoApplication {
   public static void main(String[] args) {
     SpringApplication.run(DemoApplication.class, args);
   }
-
 }

--- a/java/app/src/main/java/com/example/demo/DemoApplication.java
+++ b/java/app/src/main/java/com/example/demo/DemoApplication.java
@@ -28,7 +28,7 @@ public class DemoApplication {
   }
   //default username and password can be configured from here Username default is user and password temp
   @Bean
-  public InMemoryUserDetailsManager userDetailsManger(){
+  public InMemoryUserDetailsManager userDetailsManager(){
       UserDetails john=org.springframework.security.core.userdetails.User.builder().username("user").password("{noop}temp").roles("Employee").build();
       return new InMemoryUserDetailsManager(john);
   } 

--- a/java/app/src/main/java/com/example/demo/DemoApplication.java
+++ b/java/app/src/main/java/com/example/demo/DemoApplication.java
@@ -2,11 +2,18 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+//Security Imports
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
 
 @SpringBootApplication
+@Configuration
 public class DemoApplication {
 
   @Value("${NAME:World}")
@@ -19,6 +26,12 @@ public class DemoApplication {
       return "Hello " + name + "!";
     }
   }
+  //default username and password can be configured from here Username default is user and password temp
+  @Bean
+  public InMemoryUserDetailsManager userDetailsManger(){
+      UserDetails john=org.springframework.security.core.userdetails.User.builder().username("user").password("{noop}temp").roles("Employee").build();
+      return new InMemoryUserDetailsManager(john);
+  } 
 
   public static void main(String[] args) {
     SpringApplication.run(DemoApplication.class, args);


### PR DESCRIPTION
This PR adds **Spring Security** with basic authentication to the Java API server template
## Changes Made
**Added Spring Security dependency** (`spring-boot-starter-security`) to `pom.xml`
**Implemented in-memory authentication** with a configurable default user
**Secured all endpoints** with HTTP Basic Authentication
## Authentication Details
## Default Credentials
- **Username**: `user`
- **Password**: `temp`
- **Role**: `Employee`
Can edit these and add as per required .
I have personally used and tested this setup worked with postman as well, Further there are not tests written for this api security integration can be included. 
<a href="https://idx.google.com/new?template=https://github.com/shaiksahilrizwan/templates/tree/java-spring-security-auth/java"> <img height="32" alt="Open in IDX" src="https://cdn.idx.dev/btn/open_dark_32.svg"> </a>