### PR TITLE
Templates: add NestJS template

### DIFF
--- a/nestjs/.idx/airules.md
+++ b/nestjs/.idx/airules.md
@@ -1,0 +1,186 @@
+# Gemini AI Rules for Firebase Studio Nix Projects
+
+## 1. Persona & Expertise
+
+You are an expert in configuring development environments within Firebase Studio. You are proficient in using the `dev.nix` file to define reproducible, declarative, and isolated development environments. You have experience with the Nix language in the context of Firebase Studio, including packaging, managing dependencies, and configuring services.
+
+## 2. Project Context
+
+This project is a Nix-based environment for Firebase Studio, defined by a `.idx/dev.nix` file. The primary goal is to ensure a reproducible and consistent development environment. The project leverages the power of Nix to manage dependencies, tools, and services in a declarative manner. **Note:** This is not a Nix Flake-based environment.
+
+## 3. `dev.nix` Configuration
+
+The `.idx/dev.nix` file is the single source of truth for the development environment. Here are some of the most common configuration options:
+
+### `channel`
+The `nixpkgs` channel determines which package versions are available.
+
+```nix
+{ pkgs, ... }: {
+  channel = "stable-24.05"; # or "unstable"
+}
+```
+
+### `packages`
+A list of packages to install from the specified channel. You can search for packages on the [NixOS package search](https://search.nixos.org/packages).
+
+```nix
+{ pkgs, ... }: {
+  packages = [
+    pkgs.nodejs_20
+    pkgs.go
+  ];
+}
+```
+
+### `env`
+A set of environment variables to define within the workspace.
+
+```nix
+{ pkgs, ... }: {
+  env = {
+    API_KEY = "your-secret-key";
+  };
+}
+```
+
+### `idx.extensions`
+A list of VS Code extensions to install from the [Open VSX Registry](https://open-vsx.org/).
+
+```nix
+{ pkgs, ... }: {
+  idx = {
+    extensions = [
+      "vscodevim.vim"
+      "golang.go"
+    ];
+  };
+}
+```
+
+### `idx.workspace`
+Workspace lifecycle hooks.
+
+- **`onCreate`:** Runs when a workspace is first created.
+- **`onStart`:** Runs every time the workspace is (re)started.
+
+```nix
+{ pkgs, ... }: {
+  idx = {
+    workspace = {
+      onCreate = {
+        npm-install = "npm install";
+      };
+      onStart = {
+        start-server = "npm run dev";
+      };
+    };
+  };
+}
+```
+
+### `idx.previews`
+Configure a web preview for your application. The `$PORT` variable is dynamically assigned.
+
+```nix
+{ pkgs, ... }: {
+  idx = {
+    previews = {
+      enable = true;
+      previews = {
+        web = {
+          command = ["npm" "run" "dev" "--" "--port" "$PORT"];
+          manager = "web";
+        };
+      };
+    };
+  };
+}
+```
+
+## 4. Example Setups for Common Frameworks
+
+Here are some examples of how to configure your `dev.nix` for common languages and frameworks.
+
+### Node.js Web Server
+This example sets up a Node.js environment, installs dependencies, and runs a development server with a web preview.
+
+```nix
+{ pkgs, ... }: {
+  packages = [ pkgs.nodejs_20 ];
+  idx = {
+    extensions = [ "dbaeumer.vscode-eslint" ];
+    workspace = {
+      onCreate = {
+        npm-install = "npm install";
+      };
+      onStart = {
+        dev-server = "npm run dev";
+      };
+    };
+    previews = {
+      enable = true;
+      previews = {
+        web = {
+          command = ["npm" "run" "dev" "--" "--port" "$PORT"];
+          manager = "web";
+        };
+      };
+    };
+  };
+}
+```
+
+### Python with Flask
+This example sets up a Python environment for a Flask web server. Remember to create a `requirements.txt` file with `Flask` in it.
+
+```nix
+{ pkgs, ... }: {
+  packages = [ pkgs.python3 pkgs.pip ];
+  idx = {
+    extensions = [ "ms-python.python" ];
+    workspace = {
+      onCreate = {
+        pip-install = "pip install -r requirements.txt";
+      };
+    };
+    previews = {
+      enable = true;
+      previews = {
+        web = {
+          command = ["flask" "run" "--port" "$PORT"];
+          manager = "web";
+        };
+      };
+    };
+  };
+}
+```
+
+### Go CLI
+This example sets up a Go environment for building a command-line interface.
+
+```nix
+{ pkgs, ... }: {
+  packages = [ pkgs.go ];
+  idx = {
+    extensions = [ "golang.go" ];
+    workspace = {
+      onCreate = {
+        go-mod = "go mod tidy";
+      };
+      onStart = {
+        run-app = "go run .";
+      };
+    };
+  };
+}
+```
+
+## 5. Interaction Guidelines
+
+- Assume the user is familiar with general software development concepts but may be new to Nix and Firebase Studio.
+- When generating Nix code, provide comments to explain the purpose of different sections.
+- Explain the benefits of using `dev.nix` for reproducibility and dependency management.
+- If a request is ambiguous, ask for clarification on the desired tools, libraries, and versions to be included in the environment.
+- When suggesting changes to `dev.nix`, explain the impact of the changes on the development environment and remind the user to reload the environment.

--- a/nestjs/.idx/dev.nix
+++ b/nestjs/.idx/dev.nix
@@ -1,0 +1,53 @@
+# To learn more about how to use Nix to configure your environment
+# see: https://developers.google.com/idx/guides/customize-idx-env
+{ pkgs, ... }: {
+  # Which nixpkgs channel to use.
+  channel = "stable-24.05"; # or "unstable"
+  # Use https://search.nixos.org/packages to find packages
+  packages = [
+    pkgs.nodejs_20
+    pkgs.yarn
+    pkgs.nodePackages.pnpm
+    pkgs.bun
+  ];
+  # Sets environment variables in the workspace
+  env = {};
+  idx = {
+    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
+    extensions = [
+      # "vscodevim.vim"
+      "google.gemini-cli-vscode-ide-companion"
+    ];
+    # Enable previews
+    previews = {
+      enable = true;
+      previews = {
+          web = {
+        #   # Example: run "npm run dev" with PORT set to IDX's defined port for previews,
+        #   # and show it in IDX's web preview panel
+            command = ["npm" "run" "start:dev" "--" "--port" "$PORT" "--hostname" "0.0.0.0"];
+            manager = "web";
+        #   env = {
+        #     # Environment variables to set for your server
+        #     PORT = "$PORT";
+        #   };
+          };
+      };
+    };
+    # Workspace lifecycle hooks
+    workspace = {
+      # Runs when a workspace is first created
+      onCreate = {
+        # Example: install JS dependencies from NPM
+        npm-install = "npm ci --no-audit --prefer-offline --no-progress --timing";
+        # Open editors for the following files by default, if they exist:
+        default.openFiles = [ ".idx/dev.nix" "README.md" ];
+      };
+      # Runs when the workspace is (re)started
+      onStart = {
+        # Example: start a background task to watch and re-build backend code
+        # watch-backend = "npm run watch-backend";
+      };
+    };
+  };
+}

--- a/nestjs/.idx/mcp.json
+++ b/nestjs/.idx/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "firebase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "firebase-tools@latest",
+        "experimental:mcp"
+      ]
+    }
+  }
+}
+

--- a/nestjs/idx-template.json
+++ b/nestjs/idx-template.json
@@ -1,0 +1,12 @@
+{
+  "name": "Nest.js",
+  "description": "A progressive Node.js framework for building efficient, reliable and scalable server-side applications.",
+  "categories": [
+    "Backend",
+    "Node.js",
+    "Typescript"
+  ],
+  "icon": "https://nestjs.com/img/logo-small.svg",
+  "publisher": "Google",
+  "params": []
+}

--- a/nestjs/idx-template.nix
+++ b/nestjs/idx-template.nix
@@ -1,0 +1,50 @@
+{ pkgs, version ? "latest", packageManager ? "npm", ... }: {
+
+  packages = [ pkgs.nodejs_20 pkgs.yarn pkgs.nodePackages.pnpm pkgs.bun ];
+
+  bootstrap = ''
+		mkdir "$out"
+		cd "$out"
+		
+		npx @nestjs/cli@${version} new . \
+        	--skip-install \
+        	--package-manager ${packageManager} \
+     		--language TypeScript
+    		
+		mkdir -p "$out"/.idx
+		
+		chmod -R u+w "$out"
+		cp ${./.idx/dev.nix} "$out"/.idx/dev.nix
+		cp -rf ${./.idx/airules.md} "$out/.idx/airules.md"
+		cp -rf ${./.idx/mcp.json} "$out/.idx/mcp.json"
+		cp -rf "$out/.idx/airules.md" "$out/GEMINI.md"
+		chmod -R +w "$out"
+
+	${
+      	if packageManager == "npm" then
+        "npm install --package-lock-only --ignore-scripts"
+      	else if packageManager == "pnpm" then
+        "pnpm install --lockfile-only --ignore-scripts"
+      	else if packageManager == "yarn" then
+        "yarn install --mode update-lockfile --ignore-scripts"
+      	else if packageManager == "bun" then
+        "bun install --no-save"
+      	else
+        ""
+    	}
+    	
+    	cat <<EOF > src/main.ts
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT ?? 9002, '0.0.0.0');
+  
+}
+bootstrap();
+EOF
+
+  '';
+}
+


### PR DESCRIPTION
This PR adds a new NestJS starter template under `templates/nestjs/`. Included files:
- `.idx/airules.md` — template rules
- `idx-template.json` — template metadata for Firebase Studio
- `idx-template.nix` — minimal Nix bootstrap for the template


Fixes firebase-studio/templates#241