### PR TITLE
Update idx-template.nix file to resolve the conflicts due to ESLint in Qwik-city-vite template. @rodydavis

### DIFF
--- a/qwik-city-vite/dev.nix
+++ b/qwik-city-vite/dev.nix
@@ -12,7 +12,7 @@
   idx = {
     # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
     extensions = [
-      # "vscodevim.vim"
+      "qwik.qwik-vscode"
     ];
     workspace = {
       # Runs when a workspace is first created with this `dev.nix` file

--- a/qwik-city-vite/idx-template.nix
+++ b/qwik-city-vite/idx-template.nix
@@ -3,8 +3,25 @@
     pkgs.nodejs_20
   ];
   bootstrap = ''
+    set -e
     mkdir -p "$WS_NAME"
     npm create qwik@latest "empty" "$WS_NAME"
+    
+    # Pin @eslint/js to version 9 to avoid conflicts
+    # with eslint-plugin-qwik
+    cd "$WS_NAME"
+    node -e '
+      const fs = require("fs");
+      const path = "package.json";
+      const pkg = JSON.parse(fs.readFileSync(path, "utf-8"));
+      if (pkg.devDependencies && pkg.devDependencies["@eslint/js"]) {
+        console.log("Pinning @eslint/js to ^9.0.0");
+        pkg.devDependencies["@eslint/js"] = "^9.0.0";
+      }
+      fs.writeFileSync(path, JSON.stringify(pkg, null, 2));
+    '
+    cd ..
+    
     mkdir -p "$WS_NAME/.idx/"
     cp -rf ${./icon.png} "$WS_NAME/.idx/icon.png"
     cp -rf ${./dev.nix} "$WS_NAME/.idx/dev.nix"


### PR DESCRIPTION
Update the idx-template.nix file and dev.nix file to resolve the conflicts due to ESLint in Qwik-city-vite template.

 **Problem** : While we are testing qwik city vite template for eslint and prettier integration it gave an issue when we create workspace due to incompatible version of ESLint in Qwik.
 **Solution** : Update the configuration of idx-template.nix to stick with a stable version of ESLint which compatible for Qwik City Vite template.
 
 <a href="https://studio.firebase.google.com/new?template=https://github.com/KarthiMoorthi-37/templates/tree/FBS_qwik-city-vite/qwik-city-vite">
  <img
    height="32"
    alt="Open in Firebase Studio"
    src="https://cdn.firebasestudio.dev/btn/open_bright_32.svg">
</a>