### PR TITLE
Skill Creation Demo for Preact-vite @rodydavis

### DIFF
--- a/skills/create-preact-vite/SKILL.md
+++ b/skills/create-preact-vite/SKILL.md
@@ -31,12 +31,12 @@ Use this skill when the user wants to create a new Preact project using Vite, wi
    - Ensure Node.js is installed.
    - Create the Preact-Vite project (using the `workspace_name` and `language` inputs).
    - Install dependencies.
-   - Create the `.agent/rules/preact.md` file using the content from `resources/ai_rules.md`.
-     - Ensure the `.agent/rules/` directory exists.
+   - Create the `.agents/rules/preact.md` file using the content from `resources/ai_rules.md`.
+     - Ensure the `.agents/rules/` directory exists.
 
 3. **Final Verification**
    Check that:
    - `package.json` exists in the new project
-   - `.agent/rules/preact.md` exists
+   - `.agents/rules/preact.md` exists
    - `index.html` exists
    - `src/main.tsx` (or `src/main.jsx` if using javascript) exists

--- a/skills/create-preact-vite/SKILL.md
+++ b/skills/create-preact-vite/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: create-preact-vite
+description: Creates a new Preact project using Vite with optional TypeScript support and installs custom AI rules.
+inputs:
+  - id: workspace_name
+    name: Workspace Name
+    type: string
+    description: The name of the folder for the new project
+  - id: language
+    name: Language
+    type: enum
+    default: ts
+    options:
+      js: JavaScript
+      ts: TypeScript
+---
+
+## When to Use This Skill
+
+Use this skill when the user wants to create a new Preact project using Vite, with either JavaScript or TypeScript, and wants the project configured with custom AI rules.
+
+## Instructions
+
+1. **Read Setup Instructions**
+   Review the [setup instructions](resources/setup_instructions.md) to understand how to initialize the project and install dependencies.
+
+   *Action:* Read `resources/setup_instructions.md`.
+
+2. **Guide the User**
+   Walk the user through the steps outlined in `resources/setup_instructions.md` to:
+   - Ensure Node.js is installed.
+   - Create the Preact-Vite project (using the `workspace_name` and `language` inputs).
+   - Install dependencies.
+   - Create the `.agent/rules/preact.md` file using the content from `resources/ai_rules.md`.
+     - Ensure the `.agent/rules/` directory exists.
+
+3. **Final Verification**
+   Check that:
+   - `package.json` exists in the new project
+   - `.agent/rules/preact.md` exists
+   - `index.html` exists
+   - `src/main.tsx` (or `src/main.jsx` if using javascript) exists

--- a/skills/create-preact-vite/resources/ai_rules.md
+++ b/skills/create-preact-vite/resources/ai_rules.md
@@ -1,0 +1,78 @@
+## Gemini AI Rules for Preact with Vite Projects
+
+## 1. Persona & Expertise
+
+You are an expert front-end developer specializing in creating highly performant and lightweight web applications with Preact and Vite. You are proficient in TypeScript, JSX, and the modern JavaScript ecosystem. Your expertise includes writing efficient, reusable components, managing state with Preact's hooks, and leveraging Vite's features for a rapid development workflow.
+
+## 2. Project Context
+
+This project is a front-end application built with Preact and TypeScript, using Vite as the development server and build tool. The focus is on creating a fast and lightweight application with a minimal footprint.
+
+## 3. Coding Standards & Best Practices
+
+### General
+- **Language:** Always use TypeScript and JSX. Adhere to modern JavaScript and Preact best practices, including hooks and functional components.
+- **Styling:** Use CSS Modules or a lightweight CSS-in-JS library.
+- **Dependencies:** After suggesting new npm dependencies, remind the user to run `npm install` or `yarn add`.
+- **Testing:** Encourage the use of a modern web testing framework like Vitest and Preact Testing Library for testing components.
+
+### Preact & Vite Specific
+- **Component Structure:** Generate Preact components as functional components using hooks. Keep components small and focused on a single responsibility.
+- **State Management:** Use Preact's built-in hooks (`useState`, `useReducer`, `useContext`) for simple state management. For more complex or shared state, use Preact Signals (`@preact/signals`).
+
+### Working with Preact Signals
+Signals provide a powerful way to manage state reactively, ensuring that components only re-render when the data they depend on actually changes.
+
+- **Creating a Signal:** Create a signal to hold a piece of state.
+  ```typescript
+  import { signal } from "@preact/signals";
+
+  const count = signal(0);
+  ```
+- **Accessing a Signal's Value:** Access the `.value` property to get the current value of a signal.
+  ```typescript
+  console.log(count.value); // 0
+  ```
+- **Updating a Signal's Value:** Update the `.value` property to change the state and trigger updates in any component that uses this signal.
+  ```typescript
+  count.value++;
+  ```
+- **Using Signals in Components:** When a signal is used inside a Preact component, the component will automatically re-render whenever the signal's value changes.
+  ```tsx
+  import { signal } from "@preact/signals";
+
+  const count = signal(0);
+
+  function Counter() {
+    return (
+      <div>
+        <p>Count: {count.value}</p>
+        <button onClick={() => count.value++}>Increment</button>
+      </div>
+    );
+  }
+  ```
+- **Computed Signals:** Use `computed` to create a new signal that derives its value from other signals. The computed signal will update automatically when its dependencies change.
+  ```typescript
+  import { signal, computed } from "@preact/signals";
+
+  const count = signal(0);
+  const double = computed(() => count.value * 2);
+
+  // In a component:
+  // <p>Double: {double.value}</p>
+  ```
+- **Performance:** Signals offer excellent performance by default because they enable fine-grained updates. Components subscribe to the specific signals they use, avoiding unnecessary re-renders. Encourage this pattern for state that is shared across multiple components.
+
+- **Performance:** Emphasize Preact's performance characteristics. Write efficient rendering logic and be mindful of bundle size. Use code-splitting for larger components or routes.
+- **Vite Configuration:** When modifying Vite's configuration (`vite.config.ts`), explain the purpose of the changes, whether it's adding a plugin or modifying server options.
+- **API Keys:** Never expose API keys on the client-side. For interacting with AI services, recommend creating a backend proxy or using serverless functions to keep API keys secure.
+- **Error Handling:** Implement robust error handling and clear loading states in components that interact with external APIs or AI services.
+
+## 4. Interaction Guidelines
+
+- Assume the user is familiar with modern front-end development concepts, including virtual DOM, JSX, and hooks.
+- Provide clear, concise, and actionable code examples for Preact components and Vite configurations.
+- When generating a new component, provide the full file content for a `.tsx` file.
+- If a request is ambiguous, ask for clarification regarding component state, props, or desired behavior.
+- Break down complex component creation into smaller steps: defining state and props, writing the JSX template, and adding event handlers.

--- a/skills/create-preact-vite/resources/setup_instructions.md
+++ b/skills/create-preact-vite/resources/setup_instructions.md
@@ -60,7 +60,7 @@ This command creates a new Preact project with the following options:
 
 ## 3. Create AI Rules
 
-Create a new file at `.agent/rules/preact.md` with the content from `resources/ai_rules.md`.
+Create a new file at `.agents/rules/preact.md` with the content from `resources/ai_rules.md`.
 
 ## 4. Install Dependencies
 

--- a/skills/create-preact-vite/resources/setup_instructions.md
+++ b/skills/create-preact-vite/resources/setup_instructions.md
@@ -1,0 +1,81 @@
+# Preact-Vite Project Setup Instructions
+
+Follow these steps to initialize the project.
+
+## 1. Install prerequisites (Node.js + npm)
+
+This skill requires:
+- Node.js (recommended 20.x+)
+- npm (bundled with Node)
+
+### 1.1 Verify
+Run:
+- `node -v`
+- `npm -v`
+
+If both work, go to **Step 2**.
+
+### 1.2 Install automatically from official Node.js downloads (recommended)
+Use the provided prereq installer script that:
+- detects OS + CPU architecture
+- fetches the latest LTS from Node’s official release index
+- downloads the correct official installer/binary from nodejs.org
+- installs it
+
+Run ONE of the following depending on your OS:
+
+#### Windows (PowerShell)
+Run:
+- `powershell.exe -ExecutionPolicy Bypass -File "skills/create-preact-vite/resources/scripts/install_node_official.ps1"`
+
+Then restart terminal / Antigravity session and verify:
+- `node -v`
+- `npm -v`
+
+#### macOS / Linux (bash)
+Run:
+- `bash "skills/create-preact-vite/resources/scripts/install_node_official.sh"`
+
+Then restart shell and verify:
+- `node -v`
+- `npm -v`
+
+> Note: macOS/Linux install may require `sudo` for system-wide installation.
+
+---
+
+## 2. Create the Preact-Vite Project
+
+Set the workspace name:
+- `WS_NAME="<workspace_name>"`
+
+Run the following command to create a new Preact project using Vite. This command will create a new directory with the project files.
+
+```bash
+npm create vite@latest "$WS_NAME" -- --template preact-{{language}}
+```
+
+This command creates a new Preact project with the following options:
+- `--template preact-{{language}}`: Uses the Preact template with either `js` or `ts`.
+
+## 3. Create AI Rules
+
+Create a new file at `.agent/rules/preact.md` with the content from `resources/ai_rules.md`.
+
+## 4. Install Dependencies
+
+Run the following command to install the project dependencies:
+
+```bash
+cd "$WS_NAME" && npm install
+```
+
+## 5. Run the Development Server
+
+To view the application, run the following command to start the development server:
+
+```bash
+cd "$WS_NAME" && npm run dev
+```
+
+This will start a local development server. You can then open your browser to the specified address to see the running application.

--- a/skills/create-preact-vite/scripts/install_node_official.ps1
+++ b/skills/create-preact-vite/scripts/install_node_official.ps1
@@ -1,0 +1,103 @@
+# Installs the latest Node.js LTS from official nodejs.org releases (user-local install).
+# - Detects CPU architecture
+# - Fetches latest LTS from Node dist index.json
+# - Downloads the official ZIP
+# - Extracts to %LOCALAPPDATA%\Programs\nodejs\<version>
+# - Adds to user PATH (no admin required)
+# - Prompts to restart terminal / Antigravity
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest`
+
+function Get-LatestLtsVersion {
+  $index = Invoke-RestMethod -Uri "https://nodejs.org/dist/index.json"
+  $lts = $index | Where-Object { $_.lts -ne $false } | Select-Object -First 1
+  if (-not $lts -or -not $lts.version) {
+    throw "Could not determine latest LTS from https://nodejs.org/dist/index.json"
+  }
+  return $lts.version  # e.g., v20.11.1
+}
+
+function Get-PlatformSuffix {
+  $arch = $env:PROCESSOR_ARCHITECTURE
+  switch ($arch) {
+    "AMD64" { return "win-x64" }
+    "ARM64" { return "win-arm64" }
+    "x86"   { return "win-x86" }
+    default { throw "Unsupported Windows architecture: $arch" }
+  }
+}
+
+function Get-MajorVersion([string]$v) {
+  # v like "v20.11.1"
+  $v = $v.Trim()
+  if ($v.StartsWith("v")) { $v = $v.Substring(1) }
+  return [int]($v.Split(".")[0])
+}
+
+# If Node already installed and >= 20, do nothing.
+try {
+  $existing = & node -v 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    $major = Get-MajorVersion $existing
+    if ($major -ge 20) {
+      Write-Host "Node is already installed ($existing). No action needed."
+      Write-Host "npm version: " -NoNewline; & npm -v
+      exit 0
+    }
+    Write-Host "Node detected ($existing) but < 20; proceeding to install latest LTS."
+  }
+} catch {
+  # node not found
+}
+
+$version  = Get-LatestLtsVersion
+$platform = Get-PlatformSuffix
+$zipName  = "node-$version-$platform.zip"
+$zipUrl   = "https://nodejs.org/dist/$version/$zipName"
+
+$installBase = Join-Path $env:LOCALAPPDATA "Programs\nodejs"
+New-Item -ItemType Directory -Force -Path $installBase | Out-Null
+
+$tmpDir = Join-Path $env:TEMP ("node-install-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+$zipPath = Join-Path $tmpDir $zipName
+
+try {
+  Write-Host "Downloading $zipUrl"
+  Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath
+
+  Write-Host "Extracting to $installBase"
+  Expand-Archive -Path $zipPath -DestinationPath $installBase -Force
+
+  $extractedDir = Join-Path $installBase ("node-" + $version + "-" + $platform)
+  if (-not (Test-Path $extractedDir)) {
+    throw "Extraction failed; expected folder not found: $extractedDir"
+  }
+
+  # Add to user PATH if not present
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  if (-not $userPath) { $userPath = "" }
+
+  $already = $userPath.Split(";") | Where-Object { $_.Trim() -ieq $extractedDir }
+  if (-not $already) {
+    $newUserPath = ($extractedDir + ";" + $userPath).TrimEnd(";")
+    [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+    Write-Host "Added Node to user PATH: $extractedDir"
+  } else {
+    Write-Host "Node path already present in user PATH."
+  }
+
+  # Also update current session PATH
+  $env:Path = $extractedDir + ";" + $env:Path
+
+  Write-Host "Installed Node $version"
+  Write-Host "Verify:"
+  & node -v
+  & npm -v
+
+  Write-Host ""
+  Write-Host "Restart your terminal / Antigravity session so PATH updates fully."
+} finally {
+  if (Test-Path $tmpDir) { Remove-Item -Recurse -Force $tmpDir }
+}

--- a/skills/create-preact-vite/scripts/install_node_official.sh
+++ b/skills/create-preact-vite/scripts/install_node_official.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs latest Node.js LTS from official nodejs.org releases (user-local install).
+# - Detects OS + CPU arch
+# - Fetches latest LTS from Node dist index.json
+# - Downloads official tarball and installs under ~/.local/node/current
+# - Updates shell profile PATH (bash/zsh/profile)
+# - Prompts restart
+
+need_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+if need_cmd node; then
+  ver="$(node -v)"
+  major="${ver#v}"; major="${major%%.*}"
+  if [[ "$major" -ge 20 ]]; then
+    echo "Node is already installed ($ver). No action needed."
+    npm -v || true
+    exit 0
+  fi
+  echo "Node detected ($ver) but < 20; proceeding to install latest LTS."
+fi
+
+DL_TOOL=""
+if need_cmd curl; then DL_TOOL="curl -fsSL"
+elif need_cmd wget; then DL_TOOL="wget -qO-"
+else
+  echo "Error: need curl or wget"
+  exit 1
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Darwin) OS_TAG="darwin" ;;
+  Linux)  OS_TAG="linux" ;;
+  *)
+    echo "Unsupported OS: $OS"
+    exit 1
+    ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64) ARCH_TAG="x64" ;;
+  arm64|aarch64) ARCH_TAG="arm64" ;;
+  armv7l) ARCH_TAG="armv7l" ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+INDEX_JSON="$($DL_TOOL https://nodejs.org/dist/index.json)"
+
+# Parse latest LTS version:
+if need_cmd jq; then
+  VERSION="$(printf '%s' "$INDEX_JSON" | jq -r '.[] | select(.lts != false) | .version' | head -n 1)"
+elif need_cmd python3; then
+  VERSION="$(python3 - <<'PY'
+import json,sys
+data=json.load(sys.stdin)
+for r in data:
+    if r.get("lts") not in (False, None):
+        print(r["version"])
+        break
+PY
+<<<"$INDEX_JSON")"
+else
+  echo "Error: need jq or python3 to parse Node release index.json"
+  exit 1
+fi
+
+if [[ -z "${VERSION:-}" || "${VERSION}" == "null" ]]; then
+  echo "Error: could not determine latest LTS version"
+  exit 1
+fi
+
+PLATFORM="${OS_TAG}-${ARCH_TAG}"
+
+# Node uses .tar.gz for macOS builds, and .tar.xz for Linux builds.
+EXT="tar.xz"
+[[ "$OS_TAG" == "darwin" ]] && EXT="tar.gz"
+
+TARBALL="node-${VERSION}-${PLATFORM}.${EXT}"
+URL="https://nodejs.org/dist/${VERSION}/${TARBALL}"
+
+INSTALL_BASE="${INSTALL_BASE:-$HOME/.local/node}"
+INSTALL_DIR="${INSTALL_BASE}/${VERSION}"
+
+mkdir -p "$INSTALL_BASE"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+echo "Downloading $URL"
+if need_cmd curl; then
+  curl -fsSL "$URL" -o "$TMP/$TARBALL"
+else
+  wget -q "$URL" -O "$TMP/$TARBALL"
+fi
+
+echo "Installing to $INSTALL_DIR"
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+
+if [[ "$EXT" == "tar.gz" ]]; then
+  tar -xzf "$TMP/$TARBALL" -C "$TMP"
+else
+  tar -xJf "$TMP/$TARBALL" -C "$TMP"
+fi
+
+EXTRACTED="$TMP/node-${VERSION}-${PLATFORM}"
+if [[ ! -d "$EXTRACTED" ]]; then
+  echo "Error: expected extracted folder not found: $EXTRACTED"
+  exit 1
+fi
+
+# Move contents into versioned install dir
+cp -R "$EXTRACTED"/. "$INSTALL_DIR"/
+
+# Update 'current' symlink
+ln -sfn "$INSTALL_DIR" "$INSTALL_BASE/current"
+
+NODE_BIN="$INSTALL_BASE/current/bin"
+EXPORT_LINE="export PATH=\"$NODE_BIN:\$PATH\""
+MARKER="# >>> antigravity node >>>"
+
+write_profile() {
+  local f="$1"
+  [[ -f "$f" ]] || touch "$f"
+  if ! grep -q "$MARKER" "$f"; then
+    {
+      echo ""
+      echo "$MARKER"
+      echo "$EXPORT_LINE"
+      echo "# <<< antigravity node <<<'
+'    } >> "$f"
+'  fi
+'}
+
+# Update common profiles
+write_profile "$HOME/.bashrc"
+write_profile "$HOME/.zshrc"
+write_profile "$HOME/.profile"
+
+echo ""
+echo "Installed Node ${VERSION} under $INSTALL_BASE/current"
+echo "Restart your shell / Antigravity session, then verify:"
+echo "  node -v"
+echo "  npm -v"


### PR DESCRIPTION
This pull request adds create-preact-vite, a new skill designed to automate the process of starting a new Preact project with Vite. The main goal is to simplify the initial setup for developers by managing dependencies and generating the necessary boilerplate, providing a seamless start with a single command.

**Here's what it does:**

**Handles Node.js Installation:** It comes with scripts that check for Node.js on the user's machine. If it's missing, the skill automatically installs the correct version for their OS, preventing common setup issues.
**Generates a Starter Project:** The skill uses npm create vite@latest to create a standard project directory, sets up a package.json, adds Preact as a dependency, and includes a basic index.html and src directory with a sample component, giving developers a functional site from the very beginning. It also allows the user to choose between JavaScript and TypeScript.
**Enhances AI Assistance:** It also configures a local preact.md file, which primes the AI to act as a Preact specialist. This allows the AI to offer more intelligent and relevant support for tasks specific to Preact, like working with Preact's hooks, managing state, and leveraging Vite's features for a rapid development workflow.