### PR TITLE
skill creation for astro @rodydavis

### DIFF
--- a/Skills/create-astro/SKILL.md
+++ b/Skills/create-astro/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-astro
+description: Creates a new Astro project using the official scaffolding tool, with optional templates and installs custom AI rules.
+inputs:
+  - id: workspace_name
+    name: Workspace Name
+    type: string
+    description: The name of the folder for the new project
+  - id: template
+    name: Template
+    type: enum
+    default: minimal
+    options:
+      minimal: Minimal
+      blog: Blog
+      portfolio: Portfolio
+---
+
+## When to Use This Skill
+
+Use this skill when the user wants to create a new Astro project, and wants the project configured with custom AI rules.
+
+## Instructions
+
+1.  **Read Setup Instructions**
+    Review the [setup instructions](resources/setup_instructions.md) to understand how to initialize the project and install dependencies.
+
+    *Action:* Read `resources/setup_instructions.md`.
+
+2.  **Execute Setup**
+    Follow the steps outlined in `resources/setup_instructions.md` to:
+    - Create the Astro project (using the `workspace_name` and `template` inputs).
+    - Install dependencies.
+    - Create the `.agent/rules/astro.md` file using the content from `resources/ai_rules.md`.
+      - Ensure the `.agent/rules/` directory exists.
+
+3.  **Final Verification**
+    Check that:
+    - `package.json` exists in the new project
+    - `.agent/rules/astro.md` exists
+    - `src/pages/index.astro` exists

--- a/Skills/create-astro/SKILL.md
+++ b/Skills/create-astro/SKILL.md
@@ -31,11 +31,11 @@ Use this skill when the user wants to create a new Astro project, and wants the 
     Follow the steps outlined in `resources/setup_instructions.md` to:
     - Create the Astro project (using the `workspace_name` and `template` inputs).
     - Install dependencies.
-    - Create the `.agent/rules/astro.md` file using the content from `resources/ai_rules.md`.
-      - Ensure the `.agent/rules/` directory exists.
+    - Create the `.agents/rules/astro.md` file using the content from `resources/ai_rules.md`.
+      - Ensure the `.agents/rules/` directory exists.
 
 3.  **Final Verification**
     Check that:
     - `package.json` exists in the new project
-    - `.agent/rules/astro.md` exists
+    - `.agents/rules/astro.md` exists
     - `src/pages/index.astro` exists

--- a/Skills/create-astro/Scripts/install_node_official.ps1
+++ b/Skills/create-astro/Scripts/install_node_official.ps1
@@ -1,0 +1,82 @@
+# Installs the latest Node.js LTS from official nodejs.org releases (user-local install).
+# - Detects CPU architecture
+# - Fetches latest LTS from Node dist index.json
+# - Downloads the official ZIP
+# - Extracts to %LOCALAPPDATA%\Programs\nodejs\<version>
+# - Adds to user PATH (no admin required)
+# - Prompts to restart terminal / Antigravity
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+function Get-LatestLtsVersion {
+  $index = Invoke-RestMethod -Uri "https://nodejs.org/dist/index.json"
+  $lts = $index | Where-Object { $_.lts -ne $false } | Select-Object -First 1
+  if (-not $lts -or -not $lts.version) {
+    throw "Could not determine latest LTS from https://nodejs.org/dist/index.json"
+  }
+  return $lts.version
+}
+function Get-PlatformSuffix {
+  $arch = $env:PROCESSOR_ARCHITECTURE
+  switch ($arch) {
+    "AMD64" { return "win-x64" }
+    "ARM64" { return "win-arm64" }
+    "x86"   { return "win-x86" }
+    default { throw "Unsupported Windows architecture: $arch" }
+  }
+}
+function Get-MajorVersion([string]$v) {
+  $v = $v.Trim()
+  if ($v.StartsWith("v")) { $v = $v.Substring(1) }
+  return [int]($v.Split(".")[0])
+}
+try {
+  $existing = & node -v 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    $major = Get-MajorVersion $existing
+    if ($major -ge 20) {
+      Write-Host "Node is already installed ($existing). No action needed."
+      Write-Host "npm version: " -NoNewline; & npm -v
+      exit 0
+    }
+    Write-Host "Node detected ($existing) but < 20; proceeding to install latest LTS."
+  }
+} catch {
+}
+$version  = Get-LatestLtsVersion
+$platform = Get-PlatformSuffix
+$zipName  = "node-$version-$platform.zip"
+$zipUrl   = "https://nodejs.org/dist/$version/$zipName"
+$installBase = Join-Path $env:LOCALAPPDATA "Programs\nodejs"
+New-Item -ItemType Directory -Force -Path $installBase | Out-Null
+$tmpDir = Join-Path $env:TEMP ("node-install-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+$zipPath = Join-Path $tmpDir $zipName
+try {
+  Write-Host "Downloading $zipUrl"
+  Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath
+  Write-Host "Extracting to $installBase"
+  Expand-Archive -Path $zipPath -DestinationPath $installBase -Force
+  $extractedDir = Join-Path $installBase ("node-" + $version + "-" + $platform)
+  if (-not (Test-Path $extractedDir)) {
+    throw "Extraction failed; expected folder not found: $extractedDir"
+  }
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  if (-not $userPath) { $userPath = "" }
+  $already = $userPath.Split(";") | Where-Object { $_.Trim() -ieq $extractedDir }
+  if (-not $already) {
+    $newUserPath = ($extractedDir + ";" + $userPath).TrimEnd(";")
+    [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+    Write-Host "Added Node to user PATH: $extractedDir"
+  } else {
+    Write-Host "Node path already present in user PATH."
+  }
+  $env:Path = $extractedDir + ";" + $env:Path
+  Write-Host "Installed Node $version"
+  Write-Host "Verify:"
+  & node -v
+  & npm -v
+  Write-Host ""
+  Write-Host "Restart your terminal / Antigravity session so PATH updates fully."
+} finally {
+  if (Test-Path $tmpDir) { Remove-Item -Recurse -Force $tmpDir }
+}

--- a/Skills/create-astro/Scripts/install_node_official.sh
+++ b/Skills/create-astro/Scripts/install_node_official.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Description: This script installs the latest version of Node.js and npm using nvm.
+# It is intended to be run in a Linux or macOS environment.
+
+set -e
+
+# Function to print messages
+info() {
+    echo "[INFO] $1"
+}
+
+# 1. Install nvm (Node Version Manager)
+if ! command -v nvm &> /dev/null; then
+    info "nvm not found, installing..."
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+else
+    info "nvm is already installed."
+fi
+
+# 2. Install the latest version of Node.js
+info "Installing the latest version of Node.js..."
+nvm install node
+
+# 3. Verify the installation
+info "Verifying Node.js and npm installation..."
+node -v
+npm -v
+
+info "Node.js and npm have been successfully installed."

--- a/Skills/create-astro/resources/ai_rules.md
+++ b/Skills/create-astro/resources/ai_rules.md
@@ -1,0 +1,1 @@
+The user is building a web application with Astro, a modern front-end framework. Your primary role is to assist them in developing, debugging, and deploying their Astro project. If you need to install dependencies, use the `npm install` command. The user's project is located in the current working directory, and the application can be served by running `npm run dev`.

--- a/Skills/create-astro/resources/setup_instructions.md
+++ b/Skills/create-astro/resources/setup_instructions.md
@@ -60,16 +60,16 @@ cd {{workspace_name}} && npm install
 
 ## Step 4: Create AI Rules
 
-Create a new file at `.agent/rules/astro.md` with the following content:
+Create a new file at `.agents/rules/astro.md` with the following content:
 
 ```
 The user is building a web application with Astro, a modern front-end framework. Your primary role is to assist them in developing, debugging, and deploying their Astro project. If you need to install dependencies, use the `npm install` command. The user's project is located in the current working directory, and the application can be served by running `npm run dev`.
 ```
 
-Ensure the `.agent/rules/` directory exists before creating the file.
+Ensure the `.agents/rules/` directory exists before creating the file.
 
 ```bash
-mkdir -p .agent/rules && cat <<EOF > .agent/rules/astro.md
+mkdir -p .agents/rules && cat <<EOF > .agents/rules/astro.md
 The user is building a web application with Astro, a modern front-end framework. Your primary role is to assist them in developing, debugging, and deploying their Astro project. If you need to install dependencies, use the `npm install` command. The user's project is located in the current working directory, and the application can be served by running `npm run dev`.
 EOF
 ```

--- a/Skills/create-astro/resources/setup_instructions.md
+++ b/Skills/create-astro/resources/setup_instructions.md
@@ -1,0 +1,75 @@
+# Setup Instructions
+
+This document outlines the steps to create a new Astro project and configure it with custom AI rules.
+
+## 1. Install prerequisites (Node.js + npm)
+
+This skill requires:
+- Node.js (recommended 20.x+)
+- npm (bundled with Node)
+
+### 1.1 Verify
+Run:
+- `node -v`
+- `npm -v`
+
+If both work, go to **Step 2**.
+
+### 1.2 Install automatically from official Node.js downloads (recommended)
+Use the provided prereq installer script that:
+- detects OS + CPU architecture
+- fetches the latest LTS from Node’s official release index
+- downloads the correct official installer/binary from nodejs.org
+- installs it
+
+Run ONE of the following depending on your OS:
+
+#### Windows (PowerShell)
+Run:
+- `powershell -ExecutionPolicy Bypass -File "scripts/install_node_official.ps1"`
+
+Then restart terminal / Antigravity session and verify:
+- `node -v`
+- `npm -v`
+
+#### macOS / Linux (bash)
+Run:
+- `bash "scripts/install_node_official.sh"`
+
+Then restart shell and verify:
+- `node -v`
+- `npm -v`
+
+## Step 2: Create a New Astro Project
+
+To create a new Astro project, run the following command:
+
+```bash
+npm create astro@latest {{workspace_name}} -- --template {{template}}
+```
+
+This will scaffold a new Astro project in the specified directory with the chosen template.
+
+## Step 3: Install Dependencies
+
+Navigate into the newly created project directory and install the dependencies:
+
+```bash
+cd {{workspace_name}} && npm install
+```
+
+## Step 4: Create AI Rules
+
+Create a new file at `.agent/rules/astro.md` with the following content:
+
+```
+The user is building a web application with Astro, a modern front-end framework. Your primary role is to assist them in developing, debugging, and deploying their Astro project. If you need to install dependencies, use the `npm install` command. The user's project is located in the current working directory, and the application can be served by running `npm run dev`.
+```
+
+Ensure the `.agent/rules/` directory exists before creating the file.
+
+```bash
+mkdir -p .agent/rules && cat <<EOF > .agent/rules/astro.md
+The user is building a web application with Astro, a modern front-end framework. Your primary role is to assist them in developing, debugging, and deploying their Astro project. If you need to install dependencies, use the `npm install` command. The user's project is located in the current working directory, and the application can be served by running `npm run dev`.
+EOF
+```


### PR DESCRIPTION
Created skill for create-astro

This skill enables the create-astro template to be run independently.

It automates the creation of a new Astro.js project and installs the required dependencies based on the instructions provided within the skill, resulting in a ready-to-use development environment.