### PR TITLE
Skill Creation Demo for Dart @rodydavis

### DIFF
--- a/skills/create-dart/SKILL.md
+++ b/skills/create-dart/SKILL.md
@@ -22,10 +22,10 @@ Use this skill when the user wants to create a new Dart project.
 2. **Execute Setup**
    Follow the steps outlined in `resources/setup_instructions.md` to:
    - Create the Dart project (using the `workspace_name` input).
-   - Create the `.agent/rules/dart.md` file using the content from `resources/ai_rules.md`.
-     - Ensure the `.agent/rules/` directory exists.
+   - Create the `.agents/rules/dart.md` file using the content from `resources/ai_rules.md`.
+     - Ensure the `.agents/rules/` directory exists.
 
 3. **Final Verification**
    Check that:
    - `pubspec.yaml` exists in the new project
-   - `.agent/rules/dart.md` exists
+   - `.agents/rules/dart.md` exists

--- a/skills/create-dart/SKILL.md
+++ b/skills/create-dart/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: create-dart
+description: Creates a new Dart project.
+inputs:
+  - id: workspace_name
+    name: Workspace Name
+    type: string
+    description: The name of the folder for the new project
+---
+
+## When to Use This Skill
+
+Use this skill when the user wants to create a new Dart project.
+
+## Instructions
+
+1. **Read Setup Instructions**
+   Review the [setup instructions](resources/setup_instructions.md) to understand how to initialize the project and install dependencies.
+
+   *Action:* Read `resources/setup_instructions.md`.
+
+2. **Execute Setup**
+   Follow the steps outlined in `resources/setup_instructions.md` to:
+   - Create the Dart project (using the `workspace_name` input).
+   - Create the `.agent/rules/dart.md` file using the content from `resources/ai_rules.md`.
+     - Ensure the `.agent/rules/` directory exists.
+
+3. **Final Verification**
+   Check that:
+   - `pubspec.yaml` exists in the new project
+   - `.agent/rules/dart.md` exists

--- a/skills/create-dart/assets/watcher.dart
+++ b/skills/create-dart/assets/watcher.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:watcher/watcher.dart';
+
+Future<void> main() async {
+  final watcher = DirectoryWatcher('bin');
+  Process? serverProcess;
+
+  Future<void> startServer() async {
+    serverProcess = await Process.start(
+      'dart',
+      ['run', 'bin/server.dart'],
+      environment: {'PORT': '3000'},
+    );
+    serverProcess?.stdout.transform(utf8.decoder).listen((data) {
+      print(data);
+    });
+    serverProcess?.stderr.transform(utf8.decoder).listen((data) {
+      print(data);
+    });
+  }
+
+  Future<void> restartServer() async {
+    if (serverProcess != null) {
+      serverProcess?.kill();
+      serverProcess = null;
+    }
+    await startServer();
+  }
+
+  watcher.events.listen((event) async {
+    print('File change detected: ${event.path}');
+    await restartServer();
+  });
+
+  // Start the server initially
+  await startServer();
+}

--- a/skills/create-dart/resources/ai_rules.md
+++ b/skills/create-dart/resources/ai_rules.md
@@ -1,0 +1,138 @@
+# Gemini AI Rules for Dart Projects
+
+## 1. Persona & Expertise
+
+You are an expert Dart developer, well-versed in the Dart language, its core libraries, and the broader ecosystem. You write clean, efficient, and well-documented code, following the official Dart style guide. You have experience with asynchronous programming, testing, and compiling Dart for various targets, including native executables, web (JavaScript and Wasm), and servers.
+
+## 2. Project Context
+
+This is a general-purpose Dart project, providing a foundation for building command-line tools, server-side applications, or client-side web applications. The project adheres to the principles of modern Dart development, including sound null safety and a focus on performance and maintainability. It does **not** include Flutter; for Flutter projects, please use a Flutter-specific template.
+
+## 3. Coding Standards & Best Practices
+
+### Style and Formatting
+- **Dart Style Guide:** Strictly follow the official Dart style guide.
+- **`dart format`:** Use `dart format` to ensure consistent code formatting.
+- **Linter:** Use the Dart linter with a recommended set of rules to catch common issues.
+
+### Language Features
+- **Null Safety:** Write code that is soundly null-safe.
+- **Asynchronous Programming:** Use `Future`s, `async`, and `await` for asynchronous operations. Use `Stream`s for sequences of asynchronous events.
+- **Error Handling:** Use `try-catch` blocks for handling exceptions.
+
+### Testing
+- **Unit Testing:** Write unit tests for your logic using the `test` package.
+
+### Documentation
+- **`dartdoc`:** Write `dartdoc`-style comments for all public APIs.
+
+## 4. Common Use Cases
+
+This template can be used as a starting point for various types of Dart applications. Here are some examples:
+
+### Command-Line Applications (CLI)
+Dart is excellent for creating fast and self-contained command-line tools.
+
+- **Argument Parsing:** Use the `args` package to parse command-line arguments.
+- **Example `bin/main.dart`:**
+  ```dart
+  import 'package:args/args.dart';
+
+  void main(List<String> arguments) {
+    final parser = ArgParser()..addOption('name', abbr: 'n');
+    final argResults = parser.parse(arguments);
+    print('Hello, ${argResults['name']}!');
+  }
+  ```
+- **Running:** `dart run bin/main.dart --name=World`
+
+### Server-Side Applications
+You can build web servers using packages from `pub.dev`. The `shelf` package is a great starting point.
+
+- **Add dependencies:** `dart pub add shelf shelf_router args`
+- **Example `bin/server.dart`:**
+  ```dart
+  import 'dart:io';
+  import 'package:args/args.dart';
+  import 'package:shelf/shelf.dart';
+  import 'package:shelf/shelf_io.dart';
+  import 'package:shelf_router/shelf_router.dart';
+
+  final _router = Router()
+    ..get('/', _rootHandler)
+    ..get('/echo/<message>', _echoHandler);
+
+  Response _rootHandler(Request req) {
+    return Response.ok('Hello, World!\n');
+  }
+
+  Response _echoHandler(Request request) {
+    final message = params(request, 'message');
+    return Response.ok('$message\n');
+  }
+
+  void main(List<String> args) async {
+    final parser = ArgParser()..addOption('port', abbr: 'p');
+    final result = parser.parse(args);
+    final port = int.parse(result['port'] ?? Platform.environment['PORT'] ?? '8080');
+
+    final ip = InternetAddress.anyIPv4;
+    final handler = Pipeline().addMiddleware(logRequests()).addHandler(_router);
+    final server = await serve(handler, ip, port);
+    print('Server listening on port ${server.port}');
+  }
+  ```
+- **Running:** `dart run bin/server.dart --port=8080`
+
+### Web Applications
+Dart can be compiled to JavaScript or WebAssembly (Wasm) to run in the browser.
+
+- **Compiling to JavaScript:**
+  ```bash
+  dart compile js -o build/main.js web/main.dart
+  ```
+- **Compiling to WebAssembly:**
+  ```bash
+  dart compile wasm -o build/main.wasm web/main.dart
+  ```
+- **Note:** This is for client-side logic. For building complex UIs, consider a framework like Flutter.
+
+### Native Executables
+You can compile your Dart application into a self-contained native executable.
+
+- **Compilation Command:**
+  ```bash
+  dart compile exe bin/main.dart -o my_cli
+  ```
+- **Running the Executable:**
+  ```bash
+  ./my_cli --name=Native
+  ```
+
+## 5. Configuring Web Previews
+
+To preview a web server or web application, you need to configure the `previews` section in your `.idx/dev.nix` file. The `$PORT` variable is dynamically assigned by the environment and passed to your application.
+
+- **Example for a Shelf server:**
+  ```nix
+  idx = {
+    previews = {
+      enable = true;
+      previews = {
+        web = {
+          command = ["dart", "run", "bin/server.dart", "--port", "$PORT"];
+          manager = "web";
+        };
+      };
+    };
+  };
+  ```
+- **Applying Changes:** After modifying `.idx/dev.nix`, you'll need to rebuild your environment for the changes to take effect. You can do this from the command palette by searching for "Reload Environment".
+
+## 6. Interaction Guidelines
+
+- Assume the user is familiar with programming concepts but may be new to Dart.
+- When generating code, provide explanations for Dart-specific features like null safety, futures, and streams.
+- If a request is ambiguous, ask for clarification on the intended functionality and the target platform (e.g., command-line, web, server).
+- When suggesting new dependencies from `pub.dev`, explain their benefits and how to add them to the `pubspec.yaml` file.
+- Remind the user to run `dart pub get` after modifying the `pubspec.yaml` file.

--- a/skills/create-dart/resources/setup_instructions.md
+++ b/skills/create-dart/resources/setup_instructions.md
@@ -102,9 +102,9 @@ Got dependencies!
 Try `dart pub outdated` for more information.
 ```
 
-## 4. Configure Agent Rules
+## 4. Configure Agents Rules
 
-Create `.agent/rules/dart.md` inside the new workspace directory and copy the content from `skills/create-dart/resources/ai_rules.md`.
+Create `.agents/rules/dart.md` inside the new workspace directory and copy the content from `skills/create-dart/resources/ai_rules.md`.
 
 ## 5. Run server
 

--- a/skills/create-dart/resources/setup_instructions.md
+++ b/skills/create-dart/resources/setup_instructions.md
@@ -1,0 +1,120 @@
+# Dart Workspace Setup Instructions
+
+Follow these steps to initialize the workspace.
+
+## 1. Install prerequisites (Dart SDK)
+
+This skill requires the Dart SDK.
+
+### 1.1 Download and Unzip the SDK
+
+If the Dart SDK is not installed, you can download and unzip it.
+
+```bash
+unzip -o dartsdk-linux-x64-release.zip -d my-dart-sdk
+```
+
+**Output:**
+```
+Archive:  dartsdk-linux-x64-release.zip
+  inflating: my-dart-sdk/dart-sdk/dartdoc_options.yaml
+...
+  inflating: my-dart-sdk/dart-sdk/include/internal/dart_api_dl_impl.h
+```
+
+### 1.2 Add Dart to PATH and Verify
+
+```bash
+export PATH="$PATH:/home/user/angulartest/my-dart-sdk/dart-sdk/bin" && dart --version
+```
+
+**Output:**
+```
+Dart SDK version: 3.3.3 (stable) (Tue Mar 26 14:21:33 2024 +0000) on "linux_x64"
+```
+
+---
+
+## 2. Create the project
+
+Scaffold the Dart application.
+
+```bash
+export PATH="$PATH:/home/user/angulartest/my-dart-sdk/dart-sdk/bin" && dart create -t server-shelf "my-dart-app"
+```
+
+**Output:**
+```
+Creating my_dart_app using template server-shelf...
+
+  .gitignore
+  analysis_options.yaml
+  CHANGELOG.md
+  pubspec.yaml
+  README.md
+  Dockerfile
+  .dockerignore
+  test/server_test.dart
+  bin/server.dart
+
+Running pub get...
+  Resolving dependencies...
+  Changed 51 dependencies!
+  31 packages have newer versions incompatible with dependency constraints.
+  Try `dart pub outdated` for more information.
+
+Created project my_dart_app in my-dart-app! In order to get started, run the following commands:
+
+  cd my-dart-app
+  dart run bin/server.dart
+```
+
+### 2.1 Copy watcher utility
+
+Copy the `watcher.dart` utility from the skill resources to your new project's `bin` directory.
+
+```bash
+cp -R "skills/create-dart/assets/watcher.dart" "my-dart-app/bin/"
+```
+
+Then enter the workspace:
+
+```bash
+cd "my-dart-app"
+```
+
+## 3. Install dependencies
+
+cd into the new project directory and run `dart pub get`:
+
+```bash
+cd my-dart-app && export PATH="$PATH:/home/user/angulartest/my-dart-sdk/dart-sdk/bin" && dart pub get
+```
+
+**Output:**
+```
+Resolving dependencies...
+  _fe_analyzer_shared 67.0.0 (97.0.0 available)
+  analyzer 6.4.1 (11.0.0 available)
+...
+Got dependencies!
+31 packages have newer versions incompatible with dependency constraints.
+Try `dart pub outdated` for more information.
+```
+
+## 4. Configure Agent Rules
+
+Create `.agent/rules/dart.md` inside the new workspace directory and copy the content from `skills/create-dart/resources/ai_rules.md`.
+
+## 5. Run server
+
+Run the server. If port 8080 is in use, you can specify a different port.
+
+```bash
+cd my-dart-app && export PATH="$PATH:/home/user/angulartest/my-dart-sdk/dart-sdk/bin" && dart run bin/server.dart --port=8081
+```
+
+**Expected Output:**
+```
+Server listening on port 8081
+```

--- a/skills/create-dart/scripts/install_dart.ps1
+++ b/skills/create-dart/scripts/install_dart.ps1
@@ -1,0 +1,48 @@
+#Requires -RunAsAdministrator
+
+# 1. Determine architecture
+$arch = $env:PROCESSOR_ARCHITECTURE
+switch ($arch) {
+    "AMD64" { $archName = "x64" }
+    "ARM64" { $archName = "arm64" }
+    default { throw "Unsupported architecture: $arch" }
+}
+
+# 2. Get latest stable version
+$dartVersion = "3.3.3"
+$zipFile = "dartsdk-windows-$archName-release.zip"
+$downloadUrl = "https://storage.googleapis.com/dart-archive/channels/stable/release/$dartVersion/sdk/$zipFile"
+
+# 3. Download
+$tempDir = "$env:TEMP\dart-sdk-install"
+New-Item -ItemType Directory -Force -Path $tempDir
+$zipPath = Join-Path $tempDir $zipFile
+
+Write-Host "Downloading from $downloadUrl..."
+Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+
+# 4. Extract and Install
+$installDir = "$env:ProgramFiles\Dart"
+$sdkDir = "$installDir\dart-sdk"
+
+Write-Host "Extracting to $sdkDir..."
+Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+
+# 5. Update Path
+$dartBinPath = "$sdkDir\bin"
+$currentPath = [System.Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine)
+
+if (-not ($currentPath -split ';') -contains $dartBinPath) {
+    Write-Host "Adding $dartBinPath to system PATH..."
+    $newPath = "$currentPath;$dartBinPath"
+    [System.Environment]::SetEnvironmentVariable('Path', $newPath, [System.EnvironmentVariableTarget]::Machine)
+} else {
+    Write-Host "Dart SDK path already in system PATH."
+}
+
+# 6. Cleanup
+Write-Host "Cleaning up temporary files..."
+Remove-Item -Path $tempDir -Recurse -Force
+
+Write-Host "Dart SDK installation complete!"
+Write-Host "Please restart your shell for changes to take effect."

--- a/skills/create-dart/scripts/install_dart.sh
+++ b/skills/create-dart/scripts/install_dart.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# 1. Determine OS and architecture
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)
+    OS_NAME="linux"
+    ;;
+  Darwin)
+    OS_NAME="macos"
+    ;;
+  *)
+    echo "Unsupported OS: $OS"
+    exit 1
+    ;;
+esac
+
+case "$ARCH" in
+  x86_64)
+    ARCH_NAME="x64"
+    ;;
+  arm64 | aarch64)
+    ARCH_NAME="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+# 2. Get latest stable version
+# Using a recent stable version.
+DART_VERSION="3.3.3"
+ZIP_FILE="dartsdk-${OS_NAME}-${ARCH_NAME}-release.zip"
+DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/stable/release/${DART_VERSION}/sdk/${ZIP_FILE}"
+
+# 3. Download and extract
+INSTALL_DIR="/usr/local/lib/dart-sdk"
+TARGET_BIN="/usr/local/bin"
+TMP_DIR="/tmp/dart-sdk-install"
+
+echo "Downloading from $DOWNLOAD_URL..."
+curl -L -o "$ZIP_FILE" "$DOWNLOAD_URL"
+
+# Prepare installation directory
+sudo mkdir -p "$INSTALL_DIR"
+mkdir -p "$TMP_DIR"
+
+echo "Extracting to $TMP_DIR..."
+unzip -o "$ZIP_FILE" -d "$TMP_DIR"
+
+echo "Moving SDK to $INSTALL_DIR..."
+sudo mv "$TMP_DIR/dart-sdk"/* "$INSTALL_DIR"
+
+
+# 4. Create symlinks
+echo "Creating symlinks in $TARGET_BIN..."
+sudo ln -sf "$INSTALL_DIR/bin/dart" "$TARGET_BIN/dart"
+sudo ln -sf "$INSTALL_DIR/bin/dartaotruntime" "$TARGET_BIN/dartaotruntime"
+sudo ln -sf "$INSTALL_DIR/bin/dartdoc" "$TARGET_BIN/dartdoc"
+sudo ln -sf "$INSTALL_DIR/bin/pub" "$TARGET_BIN/pub"
+
+# 5. Cleanup
+rm "$ZIP_FILE"
+rm -rf "$TMP_DIR"
+
+echo "Dart SDK installation complete!"
+echo "Please restart your shell for changes to take effect."


### PR DESCRIPTION
This pull request adds create-dart, a new skill designed to automate the process of starting a new Dart server-side application. The main goal is to simplify the initial setup for developers by managing dependencies and generating the necessary boilerplate for a shelf server, providing a seamless start with a single command.

**Here's what it does:**

**Handles Dart SDK Installation:** It includes scripts to download and set up the Dart SDK for the user's operating system, guiding them through the installation process to prevent common setup issues.
**Generates a Modern Server Project:** The skill uses dart create to generate a complete, production-ready server project. It sets up a shelf application, giving developers a functional and modern server backend from the very beginning.
**Enhances AI Assistance:** It also configures a local dart.md rules file, which primes the AI to act as a specialist in Dart and its ecosystem. This allows the AI to offer more intelligent and relevant support for Dart development.

